### PR TITLE
Add a note about including the Taxonomy class

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,9 @@ Taxonomies are created using the `Taxonomy` class. This works indetically to the
 To create a new taxonomy simply pass the taxonomy name to the `Taxonomy` class constructor. Labels and the taxonomy slug are generated from the taxonomy name.
 
 ```php
+// Make sure to load the Taxonomy class
+use PostTypes\Taxonomy;
+
 // Create a new taxonomy
 $genres = new Taxonomy('genre');
 


### PR DESCRIPTION
When setting up a new taxonomy to add to a CPT I tend to forget to load
the Taxonomy class when following along with the docs. This is a small
reminder to make sure the right class is loaded.