### PR TITLE
Improve code examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ use PostTypes\PostType;
 // Create a books PostType
 $books = new PostType('book');
 
-// Attach the genre taxonomy, this is created below
+// Attach the genre taxonomy (which is created below)
 $books->taxonomy('genre');
 
 // Hide the date and author columns

--- a/docs/Getting-started.md
+++ b/docs/Getting-started.md
@@ -24,6 +24,8 @@ require __DIR__ . '/vendor/autoload.php';
 use PostTypes\PostType;
 
 $books = new PostType('book');
+
+$books->register();
 ```
 
 See Composers [basic usage](https://getcomposer.org/doc/01-basic-usage.md#autoloading) guide for details on working Composer and autoloading.

--- a/docs/Notes.md
+++ b/docs/Notes.md
@@ -7,10 +7,10 @@ Since 2.0 the `translation()` method has been removed. You can translate any lab
 ```php
 // Translating the PostType plural and singular names
 $books = new PostType([
-    'name' => 'book',
+    'name'     => 'book',
     'singular' => __('Book', 'YOUR_TEXTDOMAIN'),
-    'plural' => __('Books', 'YOUR_TEXTDOMAIN'),
-    'slug' => 'books'
+    'plural'   => __('Books', 'YOUR_TEXTDOMAIN'),
+    'slug'     => 'books',
 ]);
 
 // Translating Labels

--- a/docs/post-types/Columns.md
+++ b/docs/post-types/Columns.md
@@ -7,10 +7,10 @@ To modify a PostTypes admin columns use the `column()` manager. It has a variety
 To add columns to the admin edit screen pass an array of column slugs and labels to the `add()` method.
 
 ```php
-// add multiple columns and set their labels
+// Add multiple columns and set their labels
 $books->columns()->add([
     'rating' => __('Rating'),
-    'price' => __('Price')
+    'price'  => __('Price'),
 ]);
 ```
 
@@ -31,7 +31,7 @@ To rearrange columns pass an array of column slugs and position to the `order()`
 ```php
 $books->columns()->order([
     'rating' => 2,
-    'genre' => 4
+    'genre'  => 4,
 ]);
 ```
 
@@ -41,11 +41,11 @@ To set all columns to display pass an array of the column slugs and labels to th
 
 ```php
 $books->columns()->set([
-    'cb' => '<input type="checkbox" />',
-    'title' => __("Title"),
-    'genre' => __("Genres"),
-    'rating' => __("Rating"),
-    'date' => __("Date")
+    'cb'     => '<input type="checkbox" />',
+    'title'  => __('Title'),
+    'genre'  => __('Genres'),
+    'rating' => __('Rating'),
+    'date'   => __('Date'),
 ]);
 ```
 
@@ -68,9 +68,9 @@ The first option is the `meta_key` to sort the colums by.
 The second option is how the items are orders, either numerically (`true`) or alphabetically (`false`) by default.
 
 ```php
-// will make both the price and rating columns sortable and ordered numerically
+// Make both the price and rating columns sortable and ordered numerically
 $books->columns()->sortable([
-    'price' => ['price', true],
-    'rating' => ['rating', true]
+    'price'  => ['price', true],
+    'rating' => ['rating', true],
 ]);
 ```

--- a/docs/post-types/Create-a-post-type.md
+++ b/docs/post-types/Create-a-post-type.md
@@ -26,10 +26,10 @@ The post type labels and slugs are automatically generated from the post type na
 
 ```php
 $names = [
-    'name' => 'book',
+    'name'     => 'book',
     'singular' => 'Book',
-    'plural' => 'Books',
-    'slug' => 'books'
+    'plural'   => 'Books',
+    'slug'     => 'books',
 ];
 
 $books = new PostType($names);
@@ -54,7 +54,7 @@ Options for the post type are set by passing an array as the second argument in 
 
 ```php
 $options = [
-    'has_archive' => false
+    'has_archive' => false,
 ];
 
 $books = new PostType('book', $options);
@@ -68,7 +68,7 @@ Alternatively, you can set options using the `options()` method.
 $books = new PostType('book');
 
 $books->options([
-    'has_archive' => false
+    'has_archive' => false,
 ]);
 
 $books->register();
@@ -82,7 +82,7 @@ You can set the labels for the post type by passing an array as the third argume
 
 ```php
 $labels = [
-    'featured_image' => __( 'Book Cover Image' ),
+    'add_new_item' => __('Add new Book'),
 ];
 
 $books = new PostType('book', $options, $labels);
@@ -96,7 +96,7 @@ Alternatively, you can use the `labels()` method to set the labels for the post 
 $books = new PostType('books');
 
 $books->labels([
-    'add_new_item' => __('Add new Book')
+    'add_new_item' => __('Add new Book'),
 ]);
 
 $books->register();

--- a/docs/post-types/Filters.md
+++ b/docs/post-types/Filters.md
@@ -9,7 +9,7 @@ $books->filters(['genre', 'category']);
 The order the filters appear are set by the order of the items in the array.
 
 ```php
-// Display the category dropdown first.
+// Display the category dropdown first
 $books->filters(['category', 'genre']);
 ```
 

--- a/docs/taxonomies/Add-to-post-type.md
+++ b/docs/taxonomies/Add-to-post-type.md
@@ -3,13 +3,13 @@
 You can add a taxonomy to any post type by passing the post type name to the `posttype()` method.
 
 ```php
-// Create the genre Taxonomy.
+// Create the genre Taxonomy
 $genres = new Taxonomy('genre');
 
 // Attach to the books post type
 $genres->posttype('books');
 
-// Register changes to WordPress.
+// Register changes to WordPress
 $genres->register();
 ```
 

--- a/docs/taxonomies/Columns.md
+++ b/docs/taxonomies/Columns.md
@@ -8,7 +8,7 @@ $genres = new Taxonomy('genre');
 
 // Add a column to the taxonomy admin table
 $genres->columns()->add([
-    'popularity' => __('Popularity')
+    'popularity' => __('Popularity'),
 ]);
 
 // Register the taxonomy to WordPress

--- a/docs/taxonomies/Create-a-taxonomy.md
+++ b/docs/taxonomies/Create-a-taxonomy.md
@@ -90,7 +90,7 @@ Alternatively, you can use the `labels()` method to set the labels for the post 
 $genres = new Taxonomy('genre');
 
 $genres->labels([
-    'add_new_item' => __('Add new Genre')
+    'add_new_item' => __('Add new Genre'),
 ]);
 
 $genres->register();


### PR DESCRIPTION
Touch up and complete code examples, adhering mostly to WordPress style guide.

The main thing that I haven't added are [inline comments ending with periods](https://make.wordpress.org/core/handbook/best-practices/inline-documentation-standards/php/#5-1-single-line-comments) and the [spaces between parenthesis](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#space-usage):
```php
// An inline comment here
$following = __('This style');

// A WP styled comment.
$following = __( 'WP style' );
```

@jjgrainger Shall I change them all to make it 100% WP style guide compatible?