### PR TITLE
Make sure the "orderby" query var is a string when sorting by columns.

### DIFF
--- a/src/PostType.php
+++ b/src/PostType.php
@@ -496,7 +496,7 @@ class PostType
         $orderby = $query->get('orderby');
 
         // if the sorting a custom column
-        if (array_key_exists($orderby, $this->columns()->sortable)) {
+        if (is_string($orderby) && array_key_exists($orderby, $this->columns()->sortable)) {
             // get the custom column options
             $meta = $this->columns()->sortable[$orderby];
 


### PR DESCRIPTION
Hi,

The `'orderby'` query var is a mixed var `string|array`, and the method `PostType::sortSortableColumns` assumes is a string when passing it to `array_key_exists` which expects a key of type `int|string`. 
This pull request fixes the following PHP warning.
`PHP Warning:  array_key_exists(): The first argument should be either a string or an integer`