### PR TITLE
Allow for multiple taxonomies and post types to be added

### DIFF
--- a/src/PostType.php
+++ b/src/PostType.php
@@ -147,12 +147,16 @@ class PostType
 
     /**
      * Add a Taxonomy to the PostType
-     * @param  string $taxonomy The Taxonomy name to add
+     * @param  mixed $taxonomies The Taxonomy name(s) to add
      * @return $this
      */
-    public function taxonomy($taxonomy)
+    public function taxonomy($taxonomies)
     {
-        $this->taxonomies[] = $taxonomy;
+        $taxonomies = is_string($taxonomies) ? [$taxonomies] : $taxonomies;
+
+        foreach ($taxonomies as $taxonomy) {
+            $this->taxonomies[] = $taxonomy;
+        }
 
         return $this;
     }

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -129,12 +129,16 @@ class Taxonomy
 
     /**
      * Assign a PostType to register the Taxonomy to
-     * @param  string $posttype
+     * @param  mixed $posttypes
      * @return $this
      */
-    public function posttype($posttype)
+    public function posttype($posttypes)
     {
-        $this->posttypes[] = $posttype;
+        $posttypes = is_string($posttypes) ? [$posttypes] : $posttypes;
+
+        foreach ($posttypes as $posttype) {
+            $this->posttypes[] = $posttype;
+        }
 
         return $this;
     }

--- a/tests/PostTypeTest.php
+++ b/tests/PostTypeTest.php
@@ -92,6 +92,16 @@ class PostTypeTest extends TestCase
     }
 
     /** @test */
+    public function canAddMultipleTaxonomies()
+    {
+        $books = $this->books;
+
+        $books->taxonomy(['genre', 'publisher']);
+
+        $this->assertEquals($books->taxonomies, ['genre', 'publisher']);
+    }
+
+    /** @test */
     public function filtersNullOnInstantiation()
     {
         $this->assertNull($this->books->filters);

--- a/tests/TaxonomyTest.php
+++ b/tests/TaxonomyTest.php
@@ -92,6 +92,16 @@ class TaxonomyTest extends TestCase
     }
 
     /** @test */
+    public function canAddMultiplePostTypes()
+    {
+        $genres = new Taxonomy('genre');
+
+        $genres->posttype(['books', 'films']);
+
+        $this->assertEquals($genres->posttypes, ['books', 'films']);
+    }
+
+    /** @test */
     public function namesCreatedFromName()
     {
         $this->genres->createNames();


### PR DESCRIPTION
Both `taxonomy()` and `posttype()` methods can now accept arrays in order to register multiple objects in a single call.

Fixes #38 