### PR TITLE
Allow setting false to sort by alphabetical

### DIFF
--- a/src/PostType.php
+++ b/src/PostType.php
@@ -505,7 +505,7 @@ class PostType
             $meta = $this->columns()->sortableMeta($orderby);
 
             // determine type of ordering
-            if (is_string($meta)) {
+            if (is_string($meta) or !$meta[1]) {
                 $meta_key = $meta;
                 $meta_value = 'meta_value';
             } else {


### PR DESCRIPTION
This fixes a bug that does not allow you to pass in a boolean false to have columns sorted alphabetically. This fix ensures that the docs at https://posttypes.jjgrainger.co.uk/post-types/columns#sortable-columns reflect how the actual params works, where as right now if you pass a boolean false as per the docs you will still have a numeric sort. See below examples

```php
// This is currently the only way to make it sort alphabetically
$books->columns()->sortable( [
    'price'  =>  'name'
] );

// This pull-request will now sort alphabetically with this as well
$books->columns()->sortable( [
    'price'  => [ 'name', false]
] );
```
