### PR TITLE
fix child term update error

### DIFF
--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -358,7 +358,7 @@ class Taxonomy
     public function sortSortableColumns($query)
     {
         // don't modify the query if we're not in the post type admin
-        if (!is_admin() || !in_array($this->name, $query->query_vars['taxonomy'])) {
+        if (!is_admin() || !in_array($this->name, (array)$query->query_vars['taxonomy'])) {
             return;
         }
 


### PR DESCRIPTION
This fix a bug that does not allow you to update/create child terms if taxonomy has custom column(s).
