### PR TITLE
fix docblock definition

### DIFF
--- a/src/PostType.php
+++ b/src/PostType.php
@@ -198,7 +198,7 @@ class PostType
 
     /**
      * Get the Column Manager for the PostType
-     * @return PostTypes\Columns
+     * @return Columns
      */
     public function columns()
     {


### PR DESCRIPTION
The wrong namespace was used resulting with `PostTypes\PostTypes\Columns` instead of `PostTypes\Columns`