### PR TITLE
Type check taxonomy query var to prevent php 8 error

### DIFF
--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -357,6 +357,12 @@ class Taxonomy
      */
     public function sortSortableColumns($query)
     {
+        // type check the tax query var
+        $query_tax = $query->query_vars['taxonomy'] ?? [];
+        if(empty($query_tax) || ! is_array($query_tax)) {
+            return;
+        }
+
         // don't modify the query if we're not in the post type admin
         if (!is_admin() || !in_array($this->name, $query->query_vars['taxonomy'])) {
             return;


### PR DESCRIPTION
ERROR:
```
PHP Fatal error: Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, 
null given in .../vendor/jjgrainger/posttypes/src/Taxonomy.php:361
```

FIX:
Type check query var and return early
