### PR TITLE
empty array if taxonomy query var is null

### DIFF
--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -358,7 +358,7 @@ class Taxonomy
     public function sortSortableColumns($query)
     {
         // don't modify the query if we're not in the post type admin
-        if (!is_admin() || !in_array($this->name, $query->query_vars['taxonomy'])) {
+        if (!is_admin() || !in_array($this->name, $query->query_vars['taxonomy'] ?? [])) {
             return;
         }
 


### PR DESCRIPTION
ERROR:
```
PHP Fatal error: Uncaught TypeError: in_array(): Argument #2 ($haystack) must be of type array, 
null given in .../vendor/jjgrainger/posttypes/src/Taxonomy.php:361
```

FIX:
return empty array if `$query->query_vars['taxonomy']` is null.

Closes:
closes https://github.com/jjgrainger/PostTypes/issues/86, closes https://github.com/jjgrainger/PostTypes/issues/85, closes https://github.com/jjgrainger/PostTypes/issues/76
