### PR TITLE
Add Registrar Classes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,8 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space

--- a/src/PostType.php
+++ b/src/PostType.php
@@ -3,6 +3,7 @@
 namespace PostTypes;
 
 use PostTypes\Columns;
+use PostTypes\Registrars\PostTypeRegistrar;
 
 /**
  * PostType
@@ -215,67 +216,7 @@ class PostType
      */
     public function register()
     {
-        // register the PostType
-        if (!post_type_exists($this->name)) {
-            add_action('init', [$this, 'registerPostType']);
-        } else {
-            add_filter('register_post_type_args', [$this, 'modifyPostType'], 10, 2);
-        }
-
-        // register Taxonomies to the PostType
-        add_action('init', [$this, 'registerTaxonomies']);
-
-        // modify filters on the admin edit screen
-        add_action('restrict_manage_posts', [$this, 'modifyFilters']);
-
-        if (isset($this->columns)) {
-            // modify the admin edit columns.
-            add_filter("manage_{$this->name}_posts_columns", [$this, 'modifyColumns'], 10, 1);
-
-            // populate custom columns
-            add_filter("manage_{$this->name}_posts_custom_column", [$this, 'populateColumns'], 10, 2);
-
-            // run filter to make columns sortable.
-            add_filter('manage_edit-'.$this->name.'_sortable_columns', [$this, 'setSortableColumns']);
-
-            // run action that sorts columns on request.
-            add_action('pre_get_posts', [$this, 'sortSortableColumns']);
-        }
-    }
-
-    /**
-     * Register the PostType
-     * @return void
-     */
-    public function registerPostType()
-    {
-        // create options for the PostType
-        $options = $this->createOptions();
-
-        // check that the post type doesn't already exist
-        if (!post_type_exists($this->name)) {
-            // register the post type
-            register_post_type($this->name, $options);
-        }
-    }
-
-    /**
-     * Modify the existing Post Type.
-     *
-     * @return array
-     */
-    public function modifyPostType(array $args, string $posttype)
-    {
-        if ($posttype !== $this->name) {
-            return $args;
-        }
-
-        // create options for the PostType
-        $options = $this->createOptions();
-
-        $args = array_replace_recursive($args, $options);
-
-        return $args;
+        (new PostTypeRegistrar($this))->register();
     }
 
     /**
@@ -381,73 +322,6 @@ class PostType
     }
 
     /**
-     * Register Taxonomies to the PostType
-     * @return void
-     */
-    public function registerTaxonomies()
-    {
-        if (!empty($this->taxonomies)) {
-            foreach ($this->taxonomies as $taxonomy) {
-                register_taxonomy_for_object_type($taxonomy, $this->name);
-            }
-        }
-    }
-
-    /**
-     * Modify and display filters on the admin edit screen
-     * @param  string $posttype The current screen post type
-     * @return void
-     */
-    public function modifyFilters($posttype)
-    {
-        // first check we are working with the this PostType
-        if ($posttype === $this->name) {
-            // calculate what filters to add
-            $filters = $this->getFilters();
-
-            foreach ($filters as $taxonomy) {
-                // if the taxonomy doesn't exist, ignore it
-                if (!taxonomy_exists($taxonomy)) {
-                    continue;
-                }
-
-                // If the taxonomy is not registered to the post type, continue.
-                if (!is_object_in_taxonomy($this->name, $taxonomy)) {
-                    continue;
-                }
-
-                // get the taxonomy object
-                $tax = get_taxonomy($taxonomy);
-
-                // start the html for the filter dropdown
-                $selected = null;
-
-                if (isset($_GET[$taxonomy])) {
-                    $selected = sanitize_title($_GET[$taxonomy]);
-                }
-
-                $dropdown_args = [
-                    'name'            => $taxonomy,
-                    'value_field'     => 'slug',
-                    'taxonomy'        => $tax->name,
-                    'show_option_all' => $tax->labels->all_items,
-                    'hierarchical'    => $tax->hierarchical,
-                    'selected'        => $selected,
-                    'orderby'         => 'name',
-                    'hide_empty'      => 0,
-                    'show_count'      => 0,
-                ];
-
-                // Output screen reader label.
-                echo '<label class="screen-reader-text" for="cat">' . $tax->labels->filter_by_item . '</label>';
-
-                // Output dropdown for taxonomy.
-                wp_dropdown_categories($dropdown_args);
-            }
-        }
-    }
-
-    /**
      * Calculate the filters for the PostType
      * @return array
      */
@@ -469,75 +343,5 @@ class PostType
         }
 
         return $filters;
-    }
-
-    /**
-     * Modify the columns for the PostType
-     * @param  array  $columns  Default WordPress columns
-     * @return array            The modified columns
-     */
-    public function modifyColumns($columns)
-    {
-        $columns = $this->columns->modifyColumns($columns);
-
-        return $columns;
-    }
-
-    /**
-     * Populate custom columns for the PostType
-     * @param  string $column   The column slug
-     * @param  int    $post_id  The post ID
-     */
-    public function populateColumns($column, $post_id)
-    {
-        if (isset($this->columns->populate[$column])) {
-            call_user_func_array($this->columns()->populate[$column], [$column, $post_id]);
-        }
-    }
-
-    /**
-     * Make custom columns sortable
-     * @param array  $columns  Default WordPress sortable columns
-     */
-    public function setSortableColumns($columns)
-    {
-        if (!empty($this->columns()->sortable)) {
-            $columns = array_merge($columns, $this->columns()->sortable);
-        }
-
-        return $columns;
-    }
-
-    /**
-     * Set query to sort custom columns
-     * @param  WP_Query $query
-     */
-    public function sortSortableColumns($query)
-    {
-        // don't modify the query if we're not in the post type admin
-        if (!is_admin() || $query->get('post_type') !== $this->name) {
-            return;
-        }
-
-        $orderby = $query->get('orderby');
-
-        // if the sorting a custom column
-        if ($this->columns()->isSortable($orderby)) {
-            // get the custom column options
-            $meta = $this->columns()->sortableMeta($orderby);
-
-            // determine type of ordering
-            if (is_string($meta) or !$meta[1]) {
-                $meta_key = $meta;
-                $meta_value = 'meta_value';
-            } else {
-                $meta_key = $meta[0];
-                $meta_value = 'meta_value_num';
-            }
-
-            // set the custom order
-            $query->set('meta_key', $meta_key);
-            $query->set('orderby', $meta_value);
-        }
     }
 }

--- a/src/Registrars/PostTypeRegistrar.php
+++ b/src/Registrars/PostTypeRegistrar.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace PostTypes\Registrars;
+
+use PostTypes\PostType;
+
+class PostTypeRegistrar
+{
+    protected $posttype;
+
+    public function __construct(PostType $posttype)
+    {
+        $this->posttype = $posttype;
+    }
+
+    public function register()
+    {
+        // Get the PostType name.
+        $name = $this->posttype->name;
+
+        // Register the PostType
+        if (!post_type_exists($name)) {
+            add_action('init', [$this, 'registerPostType'], 10);
+        } else {
+            add_filter('register_post_type_args', [$this, 'modifyPostType'], 10, 2);
+        }
+
+        // register Taxonomies to the PostType
+        add_action('init', [$this, 'registerTaxonomies'], 10);
+
+        // modify filters on the admin edit screen
+        add_action('restrict_manage_posts', [$this, 'modifyFilters'], 10, 1);
+
+        if (isset($this->columns)) {
+            // modify the admin edit columns.
+            add_filter('manage_' . $name . '_posts_columns', [$this, 'modifyColumns'], 10, 1);
+
+            // populate custom columns
+            add_filter('manage_' . $name . '_posts_custom_column', [$this, 'populateColumns'], 10, 2);
+
+            // run filter to make columns sortable.
+            add_filter('manage_edit-' . $name . '_sortable_columns', [$this, 'setSortableColumns'], 10, 1);
+
+            // run action that sorts columns on request.
+            add_action('pre_get_posts', [$this, 'sortSortableColumns'], 10, 1);
+        }
+    }
+
+    /**
+     * Register the PostType
+     * @return void
+     */
+    public function registerPostType()
+    {
+        // create options for the PostType
+        $options = $this->posttype->createOptions();
+
+        // check that the post type doesn't already exist
+        if (!post_type_exists($this->posttype->name)) {
+            // register the post type
+            register_post_type($this->posttype->name, $options);
+        }
+    }
+
+    /**
+     * Modify the existing Post Type.
+     *
+     * @return array
+     */
+    public function modifyPostType(array $args, string $posttype)
+    {
+        if ($posttype !== $this->posttype->name) {
+            return $args;
+        }
+
+        // create options for the PostType
+        $options = $this->posttype->createOptions();
+
+        return array_replace_recursive($args, $options);
+    }
+
+    /**
+     * Register Taxonomies to the PostType
+     * @return void
+     */
+    public function registerTaxonomies()
+    {
+        if (empty($this->taxonomies)) {
+            return;
+        }
+
+        foreach ($this->posttype->taxonomies as $taxonomy) {
+            register_taxonomy_for_object_type($taxonomy, $this->posttype->name);
+        }
+    }
+
+    /**
+     * Modify and display filters on the admin edit screen
+     * @param  string $posttype The current screen post type
+     * @return void
+     */
+    public function modifyFilters($posttype)
+    {
+        // first check we are working with the this PostType
+        if ($posttype === $this->posttype->name) {
+            // calculate what filters to add
+            $filters = $this->posttype->getFilters();
+
+            foreach ($filters as $taxonomy) {
+                // if the taxonomy doesn't exist, ignore it
+                if (!taxonomy_exists($taxonomy)) {
+                    continue;
+                }
+
+                // If the taxonomy is not registered to the post type, continue.
+                if (!is_object_in_taxonomy($this->posttype->name, $taxonomy)) {
+                    continue;
+                }
+
+                // get the taxonomy object
+                $tax = get_taxonomy($taxonomy);
+
+                // start the html for the filter dropdown
+                $selected = null;
+
+                if (isset($_GET[$taxonomy])) {
+                    $selected = sanitize_title($_GET[$taxonomy]);
+                }
+
+                $dropdown_args = [
+                    'name'            => $taxonomy,
+                    'value_field'     => 'slug',
+                    'taxonomy'        => $tax->name,
+                    'show_option_all' => $tax->labels->all_items,
+                    'hierarchical'    => $tax->hierarchical,
+                    'selected'        => $selected,
+                    'orderby'         => 'name',
+                    'hide_empty'      => 0,
+                    'show_count'      => 0,
+                ];
+
+                // Output screen reader label.
+                sprintf(
+                    '<label class="screen-reader-text" for="%s">%s</label>',
+                    $taxonomy,
+                    $tax->labels->filter_by_item
+                );
+
+                // Output dropdown for taxonomy.
+                wp_dropdown_categories($dropdown_args);
+            }
+        }
+    }
+
+    /**
+     * Modify the columns for the PostType
+     * @param  array  $columns  Default WordPress columns
+     * @return array            The modified columns
+     */
+    public function modifyColumns($columns)
+    {
+        return $this->posttype->columns->modifyColumns($columns);
+    }
+    /**
+     * Populate custom columns for the PostType
+     * @param  string $column   The column slug
+     * @param  int    $post_id  The post ID
+     */
+    public function populateColumns($column, $post_id)
+    {
+        if (isset($this->columns->populate[$column])) {
+            call_user_func_array($this->posttype->columns()->populate[$column], [$column, $post_id]);
+        }
+    }
+
+    /**
+     * Make custom columns sortable
+     * @param array  $columns  Default WordPress sortable columns
+     */
+    public function setSortableColumns($columns)
+    {
+        if (!empty($this->posttype->columns()->sortable)) {
+            $columns = array_merge($columns, $this->posttype->columns()->sortable);
+        }
+
+        return $columns;
+    }
+
+    /**
+     * Set query to sort custom columns
+     * @param  WP_Query $query
+     */
+    public function sortSortableColumns($query)
+    {
+        // don't modify the query if we're not in the post type admin
+        if (!is_admin() || $query->get('post_type') !== $this->posttype->name) {
+            return;
+        }
+
+        $orderby = $query->get('orderby');
+
+        // if the sorting a custom column
+        if ($this->posttype->columns()->isSortable($orderby)) {
+            // get the custom column options
+            $meta = $this->posttype->columns()->sortableMeta($orderby);
+
+            // determine type of ordering
+            if (is_string($meta) or !$meta[1]) {
+                $meta_key = $meta;
+                $meta_value = 'meta_value';
+            } else {
+                $meta_key = $meta[0];
+                $meta_value = 'meta_value_num';
+            }
+
+            // set the custom order
+            $query->set('meta_key', $meta_key);
+            $query->set('orderby', $meta_value);
+        }
+    }
+}

--- a/src/Registrars/PostTypeRegistrar.php
+++ b/src/Registrars/PostTypeRegistrar.php
@@ -31,7 +31,7 @@ class PostTypeRegistrar
         // modify filters on the admin edit screen
         add_action('restrict_manage_posts', [$this, 'modifyFilters'], 10, 1);
 
-        if (isset($this->columns)) {
+        if (isset($this->posttype->columns)) {
             // modify the admin edit columns.
             add_filter('manage_' . $name . '_posts_columns', [$this, 'modifyColumns'], 10, 1);
 
@@ -85,7 +85,7 @@ class PostTypeRegistrar
      */
     public function registerTaxonomies()
     {
-        if (empty($this->taxonomies)) {
+        if (empty($this->posttype->taxonomies)) {
             return;
         }
 
@@ -168,7 +168,7 @@ class PostTypeRegistrar
      */
     public function populateColumns($column, $post_id)
     {
-        if (isset($this->columns->populate[$column])) {
+        if (isset($this->posttype->columns->populate[$column])) {
             call_user_func_array($this->posttype->columns()->populate[$column], [$column, $post_id]);
         }
     }

--- a/src/Registrars/TaxonomyRegistrar.php
+++ b/src/Registrars/TaxonomyRegistrar.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace PostTypes\Registrars;
+
+use PostTypes\Taxonomy;
+
+class TaxonomyRegistrar
+{
+    protected $taxonomy;
+
+    public function __construct(Taxonomy $taxonomy)
+    {
+        $this->taxonomy = $taxonomy;
+    }
+
+    public function register()
+    {
+        // Get the Taxonomy name.
+        $name = $this->taxonomy->name;
+
+        // Register the taxonomy, set priority to 9 so taxonomies are registered before PostTypes
+        add_action('init', [$this, 'registerTaxonomy'], 9);
+
+        // Assign taxonomy to post type objects
+        add_action('init', [$this, 'registerTaxonomyToObjects'], 10);
+
+        if (isset($this->taxonomy->columns)) {
+            // Modify the columns for the Taxonomy
+            add_filter("manage_edit-' . $name . '_columns", [$this, 'modifyColumns']);
+
+            // populate the columns for the Taxonomy
+            add_filter('manage_' . $name . '_custom_column', [$this, 'populateColumns'], 10, 3);
+
+            // set custom sortable columns
+            add_filter('manage_edit-' . $name . '_sortable_columns', [$this, 'setSortableColumns']);
+
+            // run action that sorts columns on request
+            add_action('parse_term_query', [$this, 'sortSortableColumns']);
+        }
+    }
+
+    /**
+     * Register the Taxonomy to WordPress
+     * @return void
+     */
+    public function registerTaxonomy()
+    {
+        // Get the existing taxonomy options if it exists.
+        $options = (taxonomy_exists($this->taxonomy->name)) ? (array) get_taxonomy($this->taxonomy->name) : [];
+
+        // create options for the Taxonomy.
+        $options = array_replace_recursive($options, $this->taxonomy->createOptions());
+
+        // register the Taxonomy with WordPress.
+        register_taxonomy($this->taxonomy->name, null, $options);
+    }
+
+    /**
+     * Register the Taxonomy to PostTypes
+     * @return void
+     */
+    public function registerTaxonomyToObjects()
+    {
+        // register Taxonomy to each of the PostTypes assigned
+        if (empty($this->taxonomy->posttypes)) {
+            return;
+        }
+
+        foreach ($this->taxonomy->posttypes as $posttype) {
+            register_taxonomy_for_object_type($this->taxonomy->name, $posttype);
+        }
+    }
+
+    /**
+     * Modify the columns for the Taxonomy
+     * @param  array  $columns  The WordPress default columns
+     * @return array
+     */
+    public function modifyColumns($columns)
+    {
+        return $this->taxonomy->columns->modifyColumns($columns);
+    }
+
+    /**
+     * Populate custom columns for the Taxonomy
+     * @param  string $content
+     * @param  string $column
+     * @param  int    $term_id
+     */
+    public function populateColumns($content, $column, $term_id)
+    {
+        if (isset($this->taxonomy->columns->populate[$column])) {
+            $content = call_user_func_array(
+                $this->taxonomy->columns()->populate[$column],
+                [$content, $column, $term_id]
+            );
+        }
+
+        return $content;
+    }
+
+    /**
+     * Make custom columns sortable
+     * @param array $columns Default WordPress sortable columns
+     */
+    public function setSortableColumns($columns)
+    {
+        if (!empty($this->taxonomy->columns()->sortable)) {
+            $columns = array_merge($columns, $this->taxonomy->columns()->sortable);
+        }
+
+        return $columns;
+    }
+
+    /**
+     * Set query to sort custom columns
+     * @param WP_Term_Query $query
+     */
+    public function sortSortableColumns($query)
+    {
+        // don't modify the query if we're not in the post type admin
+        if (!is_admin() || !in_array($this->taxonomy->name, $query->query_vars['taxonomy'] ?? [])) {
+            return;
+        }
+
+        // check the orderby is a custom ordering
+        if (isset($_GET['orderby']) && array_key_exists($_GET['orderby'], $this->taxonomy->columns()->sortable)) {
+            // get the custom sorting options
+            $meta = $this->taxonomy->columns()->sortable[$_GET['orderby']];
+
+            // check ordering is not numeric
+            if (is_string($meta)) {
+                $meta_key = $meta;
+                $orderby = 'meta_value';
+            } else {
+                $meta_key = $meta[0];
+                $orderby = 'meta_value_num';
+            }
+
+            // set the sort order
+            $query->query_vars['orderby'] = $orderby;
+            $query->query_vars['meta_key'] = $meta_key;
+        }
+    }
+}

--- a/src/Taxonomy.php
+++ b/src/Taxonomy.php
@@ -3,6 +3,7 @@
 namespace PostTypes;
 
 use PostTypes\Columns;
+use PostTypes\Registrars\TaxonomyRegistrar;
 
 /**
  * Taxonomy
@@ -162,56 +163,7 @@ class Taxonomy
      */
     public function register()
     {
-        // register the taxonomy, set priority to 9
-        // so taxonomies are registered before PostTypes
-        add_action('init', [$this, 'registerTaxonomy'], 9);
-
-        // assign taxonomy to post type objects
-        add_action('init', [$this, 'registerTaxonomyToObjects']);
-
-        if (isset($this->columns)) {
-            // modify the columns for the Taxonomy
-            add_filter("manage_edit-{$this->name}_columns", [$this, 'modifyColumns']);
-
-            // populate the columns for the Taxonomy
-            add_filter("manage_{$this->name}_custom_column", [$this, 'populateColumns'], 10, 3);
-
-            // set custom sortable columns
-            add_filter("manage_edit-{$this->name}_sortable_columns", [$this, 'setSortableColumns']);
-
-            // run action that sorts columns on request
-            add_action('parse_term_query', [$this, 'sortSortableColumns']);
-        }
-    }
-
-    /**
-     * Register the Taxonomy to WordPress
-     * @return void
-     */
-    public function registerTaxonomy()
-    {
-        // Get the existing taxonomy options if it exists.
-        $options = (taxonomy_exists($this->name)) ? (array) get_taxonomy($this->name) : [];
-
-        // create options for the Taxonomy.
-        $options = array_replace_recursive($options, $this->createOptions());
-
-        // register the Taxonomy with WordPress.
-        register_taxonomy($this->name, null, $options);
-    }
-
-    /**
-     * Register the Taxonomy to PostTypes
-     * @return void
-     */
-    public function registerTaxonomyToObjects()
-    {
-        // register Taxonomy to each of the PostTypes assigned
-        if (!empty($this->posttypes)) {
-            foreach ($this->posttypes as $posttype) {
-                register_taxonomy_for_object_type($this->name, $posttype);
-            }
-        }
+        (new TaxonomyRegistrar($this))->register();
     }
 
     /**
@@ -309,76 +261,5 @@ class Taxonomy
         ];
 
         return array_replace($labels, $this->labels);
-    }
-
-    /**
-     * Modify the columns for the Taxonomy
-     * @param  array  $columns  The WordPress default columns
-     * @return array
-     */
-    public function modifyColumns($columns)
-    {
-        $columns = $this->columns->modifyColumns($columns);
-
-        return $columns;
-    }
-
-    /**
-     * Populate custom columns for the Taxonomy
-     * @param  string $content
-     * @param  string $column
-     * @param  int    $term_id
-     */
-    public function populateColumns($content, $column, $term_id)
-    {
-        if (isset($this->columns->populate[$column])) {
-            $content = call_user_func_array($this->columns()->populate[$column], [$content, $column, $term_id]);
-        }
-
-        return $content;
-    }
-
-    /**
-     * Make custom columns sortable
-     * @param array $columns Default WordPress sortable columns
-     */
-    public function setSortableColumns($columns)
-    {
-        if (!empty($this->columns()->sortable)) {
-            $columns = array_merge($columns, $this->columns()->sortable);
-        }
-
-        return $columns;
-    }
-
-    /**
-     * Set query to sort custom columns
-     * @param WP_Term_Query $query
-     */
-    public function sortSortableColumns($query)
-    {
-        // don't modify the query if we're not in the post type admin
-        if (!is_admin() || !in_array($this->name, $query->query_vars['taxonomy'] ?? [])) {
-            return;
-        }
-
-        // check the orderby is a custom ordering
-        if (isset($_GET['orderby']) && array_key_exists($_GET['orderby'], $this->columns()->sortable)) {
-            // get the custom sorting options
-            $meta = $this->columns()->sortable[$_GET['orderby']];
-
-            // check ordering is not numeric
-            if (is_string($meta)) {
-                $meta_key = $meta;
-                $orderby = 'meta_value';
-            } else {
-                $meta_key = $meta[0];
-                $orderby = 'meta_value_num';
-            }
-
-            // set the sort order
-            $query->query_vars['orderby'] = $orderby;
-            $query->query_vars['meta_key'] = $meta_key;
-        }
     }
 }

--- a/tests/ColumnsTest.php
+++ b/tests/ColumnsTest.php
@@ -32,15 +32,31 @@ class ColumnsTest extends TestCase
     }
 
     /** @test */
-    public function canAddColumns()
+    public function canAddColumnsWithArray()
     {
         $columns = [
-            'genre' => 'Genre'
+            'genre' => 'Genre',
         ];
 
         $this->columns->add($columns);
 
         $this->assertEquals($this->columns->add, $columns);
+    }
+
+    /** @test */
+    public function canAddColumnsWithArgs()
+    {
+        $this->columns->add('genre', 'Genre');
+
+        // Auto generated label1
+        $this->columns->add('price');
+
+        $expected = [
+            'genre' => 'Genre',
+            'price' => 'Price',
+        ];
+
+        $this->assertEquals($this->columns->add, $expected);
     }
 
     /** @test */
@@ -208,5 +224,39 @@ class ColumnsTest extends TestCase
         $output = $this->columns->modifyColumns($defaults);
 
         $this->assertEquals($output, $expected);
+    }
+
+    /** @test  */
+    public function canIdentifySortableColumns()
+    {
+        $columns = [
+            'rating' => ['_rating', true],
+            'price' => '_price',
+            'sortable' => ['sortable'],
+        ];
+
+        $this->columns->sortable($columns);
+
+        $this->assertTrue($this->columns->isSortable('_rating'));
+        $this->assertTrue($this->columns->isSortable('_price'));
+        $this->assertTrue($this->columns->isSortable('sortable'));
+        $this->assertFalse($this->columns->isSortable('not_a_column'));
+    }
+
+    /** @test  */
+    public function returnsCorrectSortableMetaKey()
+    {
+        $columns = [
+            'rating' => ['_rating', true],
+            'price' => '_price',
+            'column' => ['sortable'],
+        ];
+
+        $this->columns->sortable($columns);
+
+        $this->assertEquals($this->columns->sortableMeta('rating'), ['_rating', true]);
+        $this->assertEquals($this->columns->sortableMeta('_price'), '_price');
+        $this->assertEquals($this->columns->sortableMeta('sortable'), ['sortable']);
+        $this->assertEquals($this->columns->sortableMeta('not_a_column'), '');
     }
 }

--- a/tests/PostTypeTest.php
+++ b/tests/PostTypeTest.php
@@ -160,6 +160,17 @@ class PostTypeTest extends TestCase
     }
 
     /** @test */
+    public function smartNamesCreatedFromName()
+    {
+        $story = new PostType('story');
+
+        $this->assertEquals($story->name, 'story');
+        $this->assertEquals($story->singular, 'Story');
+        $this->assertEquals($story->plural, 'Stories');
+        $this->assertEquals($story->slug, 'stories');
+    }
+
+    /** @test */
     public function passedNamesAreUsed()
     {
         $names = [
@@ -195,6 +206,33 @@ class PostTypeTest extends TestCase
         ];
 
         $this->assertEquals($options, $defaults);
+    }
+
+    /** @test */
+    public function optionsGeneratedCorrectly()
+    {
+        // Set custom options
+        $this->books->options([
+            'public' => false,
+        ]);
+
+        // Set option with helper method
+        $this->books->icon('dashicon-book-alt');
+
+        // generated options
+        $options = $this->books->createOptions();
+
+        // expected options
+        $expected = [
+            'public' => false,
+            'labels' => $this->books->createLabels(),
+            'menu_icon' => $this->books->icon,
+            'rewrite' => [
+                'slug' => $this->books->slug
+            ]
+        ];
+
+        $this->assertEquals($options, $expected);
     }
 
     /** @test */

--- a/tests/Registrars/PostTypeRegistrarTest.php
+++ b/tests/Registrars/PostTypeRegistrarTest.php
@@ -1,0 +1,24 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PostTypes\PostType;
+use PostTypes\Registrars\PostTypeRegistrar;
+
+class PostTypeRegistrarTest extends TestCase
+{
+    /** @test */
+    public function canModifyPostType()
+    {
+        $posttype = new PostType('post', [
+            'public' => false,
+        ]);
+
+        $registrar = new PostTypeRegistrar($posttype);
+
+        $options = $registrar->modifyPostType([
+            'public' => true,
+        ], 'post');
+
+        $this->assertEquals(false, $options['public']);
+    }
+}

--- a/tests/Registrars/TaxonomyRegistrarTest.php
+++ b/tests/Registrars/TaxonomyRegistrarTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use PostTypes\Registrars\TaxonomyRegistrar;
+use PostTypes\Taxonomy;
+
+class TaxonomyRegistrarTest extends TestCase
+{
+    /** @test */
+    public function canCreateTaxonomyRegistrar()
+    {
+        $taxonomy = new Taxonomy('genre');
+        $registrar = new TaxonomyRegistrar($taxonomy);
+
+        $this->assertInstanceOf(TaxonomyRegistrar::class, $registrar);
+    }
+}


### PR DESCRIPTION
This PR refactors Post Type and Taxonomy classes by moving the logic to handle registering types to WordPress to their own separate Registrar classes. This is a large change but will help towards making the codebase more maintainable.

* Provide a separation between classes that handle setting data (`PostTypes\PostType`) and those that handle the logic to register objects to WordPress (`PostTypes\Registrar\PostTypeRegistrar`).
* `PostType` and `Taxonomy` classes can focus more on interface and providing a clean API for engineers to use.
* "Registrar" classes can focus on the logic of registering post types and taxonomies to WordPress.
* Separation will improve test coverage by separating code that can be tested in isolation and code that requires integration with WordPress.
* Makes the code cleaner to read and easier to maintain.